### PR TITLE
improve error message for unavailable commands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,5 @@ export default function run (args) {
   const commands = {push}
 
   const command = commands[selectedCommand]
-  command ? command() : unknown(selectedCommand)
+  command ? command() : unknown(Object.keys(commands))
 }

--- a/src/unknown.js
+++ b/src/unknown.js
@@ -1,3 +1,4 @@
-export default command => {
-  console.log("Unknown command", command)
+export default (availableCommands) => {
+  console.log(`Available commands: ${availableCommands.join(", ")}`)
+  process.exit(1)
 }


### PR DESCRIPTION
the CLI errored when invoked without any command. let's show an error message instead